### PR TITLE
ulsdevteam/ccvgd-integral#1: Provide Docker ARGs for production and API_ROOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use official node image as the base image
 FROM node:16 as build
 
+ARG API_ROOT=http://ngrok.luozm.me:8395/ccvg/
+ARG PRODUCTION=false
+
 # Set the working directory
 #ADD . /ccvgd-frontend
 #WORKDIR /ccvgd-frontend
@@ -9,6 +12,8 @@ FROM node:16 as build
 WORKDIR /ccvgd-frontend
 
 COPY . /ccvgd-frontend
+RUN sed "s/ENV_API_ROOT/${API_ROOT}/" -i src/environments/environment.ts
+RUN sed "s/ENV_PRODUCTION/${PRODUCTION}/" -i src/environments/environment.ts
 
 # Install all the dependencies
 RUN npm install --legacy-peer-deps

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,12 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  // production: false,
-  // API_ROOT: 'http://ngrok.luozm.me:8395/ccvg/',
-  // API_ROOT: 'API_ROOT_REPLACE',
-  production: false,
-  API_ROOT: window["env"]["API_ROOT"] || "default",
-  // debug: window["env"]["debug"] || false
+  production: ENV_PRODUCTION,
+  API_ROOT: 'ENV_API_ROOT',
 };
 
 /*


### PR DESCRIPTION
This is one half of the changes to incorporate environment variables passed from the parent docker-compose into this project.

Angular does not support reading the system environment directly, so we need to replace/edit the environment.ts file.

I've added defaults for the arguments for the development settings for backwards compatibility.  As I write this, though, the better strategy would have been to leave a dev environment.ts file in place, then use Docker to replace the environment variables in environment.prod.ts, and run the build with the prod flag.

Take a look at this, and when it make sense, complete the merge.